### PR TITLE
fix: reload clip when url hash changed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -136,14 +136,15 @@ export default {
   created(){
     this.doLogin();
     let that = this;
-    window.onhashchange=function(event){
-      window.location.href=event.newURL;
+    window.onhashchange = function(event){
+      window.location.href = event.newURL;
       that.doLogin();
     }
   },
   methods: {
     login() {
       if (this.cbName === null || this.cbPass === null) return;
+      if(this.ws) this.ws.close();
       this.ws = new window.WebSocket(`${this.wsUrl}/${this.cbName}/${this.cbPass}`);
       this.ws.onopen = this.onopen;
       this.ws.onmessage = this.onmessage;

--- a/src/App.vue
+++ b/src/App.vue
@@ -134,13 +134,11 @@ export default {
     }
   },
   created(){
-    if(document.location.hash !== "" || document.location.hash !== "#/"){
-      var arr = document.location.hash.split("/");
-      this.cbName = arr[1];
-      this.cbPass = arr[2];
-      if(this.cbName !== undefined && this.cbPass !== undefined) {
-      	this.login();
-      }
+    this.doLogin();
+    let that = this;
+    window.onhashchange=function(event){
+      window.location.href=event.newURL;
+      that.doLogin();
     }
   },
   methods: {
@@ -154,6 +152,16 @@ export default {
       this.isLogining = true;
       this.loginBtnDisable = true;
       document.location.hash = "/" + this.cbName + "/" + this.cbPass;
+    },
+    doLogin() {
+      if(document.location.hash !== "" || document.location.hash !== "#/"){
+        var arr = document.location.hash.split("/");
+        this.cbName = arr[1];
+        this.cbPass = arr[2];
+        if(this.cbName !== undefined && this.cbPass !== undefined) {
+          this.login();
+        }
+      }
     },
     onopen() {
       this.msg = [];


### PR DESCRIPTION
Improve the user experience, fix the problem that the browser Back <kbd>←</kbd> button fails to return to the login interface;
Fixed the problem that modifying `hash URL` could not jump to the new clipboard directly from a existing clip.